### PR TITLE
Fix the asynchronous cherrypy wrapper

### DIFF
--- a/cherrypy/cherrypy.xml
+++ b/cherrypy/cherrypy.xml
@@ -4,9 +4,11 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="Cherry Py Synchronous" id="cherrypy" tool_type="data_source">
+<tool name="Cherry Py Synchronous" id="cherrypy" tool_type="data_source" version="1.0.0" profile="20.09">
     <description>test</description>
-    <command interpreter="python">data_source.py $output $__app__.config.output_size_limit</command>
+    <command><![CDATA[
+        python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit
+    ]]></command>
     <inputs action="http://localhost:8090/getdata" check_values="false" method="post">
         <display>go to cherrypy server $GALAXY_URL</display>
         <param name="GALAXY_URL" type="baseurl" value="/tool_runner" />
@@ -25,7 +27,7 @@
         </request_param>
     </request_param_translation>
     <uihints minwidth="800"/>
-    <outputs>
+    <outputs provided_metadata_style="legacy">
         <data name="output" format="tabular" label="${tool.name}"/>
     </outputs>
     <options sanitize="False" refresh="True"/>

--- a/cherrypy/cherrypy_async.xml
+++ b/cherrypy/cherrypy_async.xml
@@ -4,9 +4,11 @@
     the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
     initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
 -->
-<tool name="Cherry Py Async" id="cherrypy_async" tool_type="data_source">
+<tool name="Cherry Py Async" id="cherrypy_async" tool_type="data_source_async" version="1.0.0" profile="21.09">
     <description>test</description>
-    <command interpreter="python">data_source.py $output $__app__.config.output_size_limit</command>
+    <command><![CDATA[
+        python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit
+    ]]></command>
     <inputs action="http://localhost:8090/getdata_async" check_values="false" method="get">
         <display>go to cherrypy server $GALAXY_URL</display>
         <param name="GALAXY_URL" type="baseurl" value="/async/cherrypy_async" />
@@ -23,7 +25,7 @@
         </request_param>
     </request_param_translation>
     <uihints minwidth="800"/>
-    <outputs>
+    <outputs provided_metadata_style="legacy">
         <data name="output" format="tabular" label="${tool.name}"/>
     </outputs>
     <options sanitize="False" refresh="True"/>

--- a/flask/async.xml
+++ b/flask/async.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
-<tool name="DataSource Test Async" id="ds_test_async" tool_type="data_source_async" version="1.0.1">
+<tool name="DataSource Test Async" id="ds_test_async" tool_type="data_source_async" version="1.0.2" profile="21.09">
 	<description>Test Async</description>
-    <command interpreter="python">
-        data_source.py $output $__app__.config.output_size_limit
-    </command>
+    <command><![CDATA[
+        python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit
+    ]]></command>
     <inputs action="http://localhost:4001/" check_values="false" method="get" target="_top">
 		<display>go to Async Datasource $GALAXY_URL</display>
     </inputs>
@@ -12,7 +12,7 @@
         <request_param galaxy_name="URL_method" remote_name="URL_method" missing="get" />
     </request_param_translation>
 	<uihints minwidth="800"/>
-	<outputs>
+	<outputs provided_metadata_style="legacy">
 		<data name="output" format="tabular" />
 	</outputs>
 	<options sanitize="False" refresh="True"/>

--- a/flask/sync.xml
+++ b/flask/sync.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
-<tool name="DataSource Test Sync" id="ds_test_sync" tool_type="data_source" version="1.0.1">
+<tool name="DataSource Test Sync" id="ds_test_sync" tool_type="data_source" version="1.0.2" profile="20.09">
 	<description>Test Sync</description>
-    <command interpreter="python">
-        data_source.py $output $__app__.config.output_size_limit
-    </command>
+    <command><![CDATA[
+        python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit
+    ]]></command>
     <inputs action="http://localhost:4000/" check_values="false" method="get" target="_top">
 		<display>go to Sync Datasource $GALAXY_URL</display>
     </inputs>
@@ -12,7 +12,7 @@
         <request_param galaxy_name="URL_method" remote_name="URL_method" missing="get" />
     </request_param_translation>
 	<uihints minwidth="800"/>
-	<outputs>
+	<outputs provided_metadata_style="legacy">
 		<data name="output" format="tabular" />
 	</outputs>
 	<options sanitize="False" refresh="True"/>


### PR DESCRIPTION
Asynchronous data source tools have to declare a `tool_type="data_source_async"`.

Also modernizes the cherrypy and flask wrappers to use modern compatible wrapper profiles. In case of the sync versions this seems to be 20.09 (later profiles cause an import error for the galaxy module). All versions need to declare `provided_metadata_style="legacy"` on their outputs.